### PR TITLE
Add refresh function 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ set(VERSION_PATCH 0)
 include(FindPkgConfig)
 include(GNUInstallDirs)
 
+option(ENABLE_UPSTART "Enable upstart" off)
+
 pkg_search_module(ANDROIDPROPS libandroid-properties)
 
 set(TARGET deviceinfo)
@@ -18,5 +20,6 @@ include_directories(headers)
 add_subdirectory(headers)
 add_subdirectory(src)
 add_subdirectory(tools)
+add_subdirectory(data)
 
 install(DIRECTORY configs/ DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/device-info)

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,0 +1,19 @@
+FILE(GLOB systemd_file "${CMAKE_CURRENT_SOURCE_DIR}/deviceinfo-refresh.service")
+FILE(GLOB upstart_file "${CMAKE_CURRENT_SOURCE_DIR}/deviceinfo-refresh.conf")
+
+pkg_check_modules(SYSTEMD systemd)
+if (${SYSTEMD_FOUND})
+  pkg_get_variable(SYSTEMD_SYSTEM_DIR systemd systemdsystemunitdir)
+  message (STATUS "${SYSTEMD_SYSTEM_DIR} is the systemd system unit file install dir")
+  message(STATUS "${systemd_file} is your file")
+  # install it
+  install (FILES "${systemd_file}"
+           DESTINATION "${SYSTEMD_SYSTEM_DIR}")
+endif()
+
+if (ENABLE_UPSTART)
+    message("Installing upstart files")
+    install(FILES ${upstart_file}
+        DESTINATION /etc/init
+    )
+endif()

--- a/data/deviceinfo-refresh.conf
+++ b/data/deviceinfo-refresh.conf
@@ -1,0 +1,7 @@
+description "Refresh device info"
+
+task
+
+start on started dbus
+
+exec device-info refresh

--- a/data/deviceinfo-refresh.service
+++ b/data/deviceinfo-refresh.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Refresh device info
+after=dbus.service
+
+[Service]
+ExecStart=device-info refresh
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/control
+++ b/debian/control
@@ -3,8 +3,10 @@ Section: admin
 Priority: optional
 Build-Depends: cmake (>= 2.8.10),
                debhelper (>= 9),
+               dh-systemd,
                pkg-config,
-               libandroid-properties-dev
+               libandroid-properties-dev,
+               systemd,
 Maintainer: Marius Gripsgard <marius@ubports.com>
 Standards-Version: 3.9.5
 Homepage: https://github.com/ubports/deviceinfo
@@ -33,3 +35,12 @@ Depends: ${misc:Depends},
          ${shlibs:Depends},
 Description: Tools to detect and configure devices 
  Tools to detect and configure devices 
+
+Package: deviceinfo
+Section: admin
+Architecture: any
+Depends: ${misc:Depends},
+         ${shlibs:Depends},
+         deviceinfo-tools
+Description: Configures and provide infomation about devices
+ Configures and provide infomation about devices

--- a/debian/deviceinfo.install
+++ b/debian/deviceinfo.install
@@ -1,0 +1,2 @@
+lib/systemd/system/deviceinfo-refresh.service
+etc/init/deviceinfo-refresh.conf

--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,7 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@ --parallel --buildsystem cmake --fail-missing
+	dh $@ --parallel --buildsystem cmake --fail-missing --with systemd
+
+override_dh_auto_configure:
+	dh_auto_configure -- -DENABLE_UPSTART=yes

--- a/tools/device-info.cpp
+++ b/tools/device-info.cpp
@@ -26,6 +26,30 @@ void print(std::string str) {
     std::cout << str << std::endl;
 }
 
+int refresh(std::shared_ptr<DeviceInfo> info) {
+    // Setup hostname chassis
+    std::string cmd = "hostnamectl set-chassis ";
+    switch (info->deviceType()) {
+        case DeviceInfo::DeviceType::Phone:
+            cmd += "handset";
+            break;
+        case DeviceInfo::DeviceType::Tablet:
+            cmd += "tablet";
+            break;
+        default:
+            cmd += "desktop";
+            break;
+    }
+
+    if (system(cmd.c_str()) != 0) {
+        print("Failed to set hostname chassis");
+        return 1;
+    }
+
+    print("Refresh of device info done");
+    return 0;
+}
+
 int get(std::string arg, std::shared_ptr<DeviceInfo> info) {
     if (arg == "Name") {
         print(info->name());
@@ -113,11 +137,16 @@ void help() {
     print("device-info usage:");
     print(" - device-info            - list all about device");
     print(" - device-info get [prop] - get spesific prop");
+    print(" - device-info refresh    - refresh deviceinfo cache and set system properies");
 }
 
 int main (int argc, char *argv[]) {
     if (argc == 1) {
         return printAboutMe(std::make_shared<DeviceInfo>());
+    } else if (argc == 2) {
+        std::string argv1 = argv[1];
+        if (argv1 == "refresh")
+            return refresh(std::make_shared<DeviceInfo>(DeviceInfo::PrintMode::Info));
     } else if (argc == 3) {
         std::string argv1 = argv[1];
         if (argv1 == "get") {


### PR DESCRIPTION
This adds a refresh function to device-info to allow device info set
setup hostname chassis and in the future setup its cache to allow
confined apps to quarry info.

This also adds upstart and systemd configs to set this on boot