### PR TITLE
Refactor platform dependent information getter logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ include(FindPkgConfig)
 include(GNUInstallDirs)
 
 pkg_search_module(ANDROIDPROPS libandroid-properties)
+if(NOT ANDROIDPROPS_FOUND)
+    message(WARNING "Did not find android properties, bulding without!")
+endif()
 
 set(TARGET deviceinfo)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,14 +1,22 @@
+if(ANDROIDPROPS_FOUND)
+    add_definitions(-DHAVE_PROPS)
+
+    set(HALIUM_SRC
+        platform/halium.cpp
+    )
+endif()
+
 add_library(${TARGET} SHARED
     iniparser.cpp
     config.cpp
     device.cpp
     deviceinfo.cpp
     logger.cpp
-)
 
-if(ANDROIDPROPS_FOUND)
-    add_definitions(-DHAVE_PROPS)
-endif()
+    platform/platform.cpp
+    platform/linux.cpp
+    ${HALIUM_SRC}
+)
 
 add_definitions(-DENABLE_LEGACY)
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -34,6 +34,7 @@
 #include "deviceinfo.h"
 #include "iniparser.h"
 #include "logger.h"
+#include "platform/platform.h"
 
 #define CONFIG_PATH "/etc/device-info/"
 #define DEFAULT_CONFIG_PATH "default"
@@ -57,10 +58,10 @@
 #define LEGACY_PATH "/etc/ubuntu-touch-session.d/"
 #endif
 
-Config::Config(Device *device)
-    : m_device(device)
+Config::Config(std::shared_ptr<Platform> platform)
+    : m_platform(platform)
 {
-    auto detectedName = getEnv(ENV_DEVICE_NAME, device->detectName().c_str());
+    auto detectedName = getEnv(ENV_DEVICE_NAME, platform->name().c_str());
 
     // Transform to lowercase
     std::transform(detectedName.begin(), detectedName.end(), detectedName.begin(), ::tolower);
@@ -108,12 +109,12 @@ bool Config::contains(std::string prop, bool defaults)
         if (!m_defaultIni)
             return false;
 
-        auto detected = DeviceInfo::deviceTypeToString(m_device->detectType(false));
+        auto detected = DeviceInfo::deviceTypeToString(m_platform->deviceType());
         if (m_defaultIni->sections().count(detected)) {
             if (m_defaultIni->contains(detected, prop)) 
                 return true;
         }
-        auto driverType = DeviceInfo::driverTypeToString(m_device->driverType());
+        auto driverType = DeviceInfo::driverTypeToString(m_platform->driverType());
         if (m_defaultIni->sections().count(driverType)) {
             if (m_defaultIni->contains(driverType, prop)) 
                 return true;
@@ -145,12 +146,12 @@ std::string Config::get(std::string prop, bool defaults, std::string defaultValu
         if (!m_defaultIni)
             return defaultValue;
 
-        auto detected = DeviceInfo::deviceTypeToString(m_device->detectType(false));
+        auto detected = DeviceInfo::deviceTypeToString(m_platform->deviceType());
         if (m_defaultIni->sections().count(detected)) {
             if (m_defaultIni->contains(detected, prop)) 
                 return m_defaultIni->get(detected, prop, defaultValue);
         }
-        auto driverType = DeviceInfo::driverTypeToString(m_device->driverType());
+        auto driverType = DeviceInfo::driverTypeToString(m_platform->driverType());
         if (m_defaultIni->sections().count(driverType)) {
             if (m_defaultIni->contains(driverType, prop)) 
                 return m_defaultIni->get(driverType, prop, defaultValue);

--- a/src/config.h
+++ b/src/config.h
@@ -25,11 +25,11 @@
 #include <vector>
 #endif
 
-class Device;
+class Platform;
 class IniParser;
 class Config {
 public:
-    Config(Device *device);
+    Config(std::shared_ptr<Platform> platform);
 
     std::string get(std::string prop, bool defaults, std::string defaultValue);
     std::string get(std::string prop, bool defaults);
@@ -48,7 +48,7 @@ private:
     std::string toLegacy(std::string str);
 #endif
 
-    Device *m_device;
+    std::shared_ptr<Platform> m_platform;
     std::shared_ptr<IniParser> m_deviceIni;
     std::shared_ptr<IniParser> m_defaultIni;
 };

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -20,6 +20,7 @@
 
 #include "config.h"
 #include "logger.h"
+#include "platform/platform.h"
 
 #include <memory>
 #include <string>
@@ -42,8 +43,8 @@
 #define LINUX_MODEL "/proc/device-tree/model"
 
 Device::Device() :
-    m_isHalium(hasHaliumProp(DEVICE_PROP_KEY)),
-    m_config(std::make_shared<Config>(this))
+    m_platform(Platform::create()),
+    m_config(std::make_shared<Config>(m_platform))
 {
 }
 
@@ -53,12 +54,13 @@ std::string Device::name()
         return m_config->get("Name", false);
     }
 
-    auto detect = detectName();
-    if (detect != "unknown")
-        return detect;
+    if (m_platform->hasValidName()) {
+        return m_platform->name();
+    }
 
-    // If all else fails
-    return m_config->get("Name", true, "generic");
+    // If all else fails, platform returns default value for the
+    // current platform use this if config has no set value
+    return m_config->get("Name", true, m_platform->name());
 }
 
 std::string Device::prettyName()
@@ -67,15 +69,13 @@ std::string Device::prettyName()
         return m_config->get("PrettyName", false);
     }
 
-    if (m_isHalium) {
-        if (hasHaliumProp(VENDOR_MODEL_PROP_KEY))
-            return getHaliumProp(VENDOR_MODEL_PROP_KEY);
-        else if (hasHaliumProp(MODEL_PROP_KEY))
-            return getHaliumProp(MODEL_PROP_KEY);
+    if (m_platform->hasValidPrettyName()) {
+        return m_platform->prettyName();
     }
 
-    // If all else fails
-    return m_config->get("PrettyName", true, "Generic device");
+    // If all else fails, platform returns default value for the
+    // current platform use this if config has no set value
+    return m_config->get("PrettyName", true, m_platform->prettyName());
 }
 
 int Device::gridUnit()
@@ -105,7 +105,6 @@ bool Device::contains(std::string prop) {
     return m_config->contains(prop, true);
 }
 
-
 DeviceInfo::DeviceType Device::deviceType()
 {
     if (m_config->contains("DeviceType", false)) {
@@ -113,85 +112,15 @@ DeviceInfo::DeviceType Device::deviceType()
         return DeviceInfo::deviceTypeFromString(typeStr);
     }
 
-    auto detected = detectType(true);
-    if (detected != DeviceInfo::DeviceType::Unknown)
-        return detected;
-
-    return DeviceInfo::deviceTypeFromString(m_config->get("DeviceType", true, "desktop"));
-}
-
-std::string Device::detectName() {
-    if (m_isHalium) {
-        if (hasHaliumProp(VENDOR_DEVICE_PROP_KEY))
-            return getHaliumProp(VENDOR_DEVICE_PROP_KEY);
-        else if (hasHaliumProp(DEVICE_PROP_KEY))
-            return getHaliumProp(DEVICE_PROP_KEY);
+    if (m_platform->hasValidDeviceType()) {
+        return m_platform->deviceType();
     }
 
-    // If it's not halium or does not have device prop, try dtb
-    auto model = readFile(LINUX_MODEL);
-    if (!model.empty())
-        return model;
-
-    return "unknown";
-}
-
-DeviceInfo::DeviceType Device::detectType(bool returnUknown) {
-    if (m_isHalium) {
-        auto chara = getHaliumProp(CHARA_PROP_KEY);
-        if (chara.find("tablet") != std::string::npos)
-            return DeviceInfo::DeviceType::Tablet;
-
-        // As this is a halium device, the best guess will be phone
-        return DeviceInfo::DeviceType::Phone;
-    }
-
-    // At this point we guess it's a desktop
-    return returnUknown ? DeviceInfo::DeviceType::Unknown : DeviceInfo::DeviceType::Desktop;
+    auto defaultValue = DeviceInfo::deviceTypeToString(m_platform->deviceType());
+    return DeviceInfo::deviceTypeFromString(m_config->get("DeviceType", true, defaultValue));
 }
 
 DeviceInfo::DriverType Device::driverType()
 {
-    if (m_isHalium)
-        return DeviceInfo::DriverType::Halium;
-
-    return DeviceInfo::DriverType::Linux;
-}
-
-std::string Device::getHaliumProp(const char* prop)
-{
-    return getHaliumProp(prop, "");
-}
-
-std::string Device::getHaliumProp(const char* prop, const char* default_value)
-{
-    std::string ret;
-#ifdef HAVE_PROPS
-    char value[PROP_VALUE_MAX];
-    property_get(prop, value, default_value);
-    ret = value;
-#endif
-    return ret;
-}
-
-bool Device::hasHaliumProp(const char* key)
-{
-    bool ret = false;
-#ifdef HAVE_PROPS
-    char const* default_value = "hasnodevice";
-    char value[PROP_VALUE_MAX];
-    property_get(key, value, default_value);
-    ret = strcmp(value, default_value) != 0;
-#endif
-    return ret;
-}
-
-std::string Device::readFile(std::string file)
-{
-    std::ifstream model(file);
-    std::string ret;
-    if (model.good())
-        ret = std::string(std::istreambuf_iterator<char>{model},
-                          std::istreambuf_iterator<char>());
-    return ret;
+    return m_platform->driverType();
 }

--- a/src/platform/halium.cpp
+++ b/src/platform/halium.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2020 UBports foundation.
+ * Author(s): Marius Gripsgard <marius@ubports.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 3, as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+ * SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "halium.h"
+
+#include <memory>
+#include <string>
+#include <cstring>
+
+#include <hybris/properties/properties.h>
+
+// Android props
+#define DEVICE_PROP_KEY "ro.product.device"
+#define MODEL_PROP_KEY "ro.product.model"
+#define VENDOR_DEVICE_PROP_KEY "ro.product.vendor.device"
+#define VENDOR_MODEL_PROP_KEY "ro.product.vendor.model"
+#define CHARA_PROP_KEY "ro.build.characteristics"
+
+std::string platform::Halium::name()
+{
+    if (hasHaliumProp(VENDOR_DEVICE_PROP_KEY))
+        return getHaliumProp(VENDOR_DEVICE_PROP_KEY);
+    else if (hasHaliumProp(DEVICE_PROP_KEY))
+        return getHaliumProp(DEVICE_PROP_KEY);
+
+    return "unknown";
+}
+
+bool platform::Halium::hasValidName()
+{
+    return hasHaliumProp(VENDOR_DEVICE_PROP_KEY) ||
+           hasHaliumProp(DEVICE_PROP_KEY);
+}
+
+std::string platform::Halium::prettyName()
+{
+    if (hasHaliumProp(VENDOR_MODEL_PROP_KEY))
+        return getHaliumProp(VENDOR_MODEL_PROP_KEY);
+    else if (hasHaliumProp(MODEL_PROP_KEY))
+        return getHaliumProp(MODEL_PROP_KEY);
+
+    return "unknown";
+}
+
+bool platform::Halium::hasValidPrettyName()
+{
+    return hasHaliumProp(VENDOR_MODEL_PROP_KEY) ||
+           hasHaliumProp(MODEL_PROP_KEY);
+}
+
+DeviceInfo::DeviceType platform::Halium::deviceType() {
+    auto chara = getHaliumProp(CHARA_PROP_KEY);
+    if (chara.find("tablet") != std::string::npos)
+        return DeviceInfo::DeviceType::Tablet;
+
+    // As this is a halium device, the best guess will be phone
+    return DeviceInfo::DeviceType::Phone;
+}
+
+bool platform::Halium::hasValidDeviceType()
+{
+    return hasHaliumProp(CHARA_PROP_KEY);
+}
+
+DeviceInfo::DriverType platform::Halium::driverType()
+{
+    return DeviceInfo::DriverType::Halium;
+}
+
+std::string platform::Halium::getHaliumProp(const char* prop)
+{
+    return getHaliumProp(prop, "");
+}
+
+std::string platform::Halium::getHaliumProp(const char* prop, const char* default_value)
+{
+    char value[PROP_VALUE_MAX];
+    property_get(prop, value, default_value);
+    return std::string(value);
+}
+
+bool platform::Halium::hasHaliumProp(const char* key)
+{
+    char const* default_value = "hasnodevice";
+    char value[PROP_VALUE_MAX];
+    property_get(key, value, default_value);
+    return strcmp(value, default_value) != 0;
+}
+
+bool platform::Halium::usable()
+{
+    return hasHaliumProp(VENDOR_DEVICE_PROP_KEY) ||
+           hasHaliumProp(DEVICE_PROP_KEY);
+}

--- a/src/platform/halium.h
+++ b/src/platform/halium.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 UBports foundation.
+ * Copyright (C) 2020 UBports foundation.
  * Author(s): Marius Gripsgard <marius@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify it under
@@ -18,24 +18,30 @@
 
 #pragma once
 
-#include "deviceinfo.h"
+#include <memory>
 
-class Config;
-class Platform;
-class Device {
+#include "platform.h"
+
+namespace platform {
+class Halium : public Platform {
 public:
-    Device();
+    Halium() = default;
 
-    std::string name();
-    std::string prettyName();
-    DeviceInfo::DeviceType deviceType();
-    DeviceInfo::DriverType driverType();
-    int gridUnit();
+    std::string name() override;
+    std::string prettyName() override;
+    DeviceInfo::DeviceType deviceType() override;
+    DeviceInfo::DriverType driverType() override;
 
-    // get props that does not have auto detection
-    std::string get(std::string prop, std::string defaultValue);
-    bool contains(std::string prop);
+    bool hasValidName() override;
+    bool hasValidPrettyName() override;
+    bool hasValidDeviceType() override;
+
+    static bool usable();
 private:
-    std::shared_ptr<Platform> m_platform;
-    std::shared_ptr<Config> m_config;
+    std::string getHaliumProp(const char* prop);
+    std::string getHaliumProp(const char* prop, const char* default_value);\
+
+    // Static as this is used by usable()
+    static bool hasHaliumProp(const char* key);
 };
+}

--- a/src/platform/linux.cpp
+++ b/src/platform/linux.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2020 UBports foundation.
+ * Author(s): Marius Gripsgard <marius@ubports.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 3, as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+ * SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "linux.h"
+
+#include <memory>
+#include <string>
+#include <iterator>
+#include <fstream>
+#include <unistd.h>
+
+// dts based model
+#define LINUX_MODEL "/proc/device-tree/model"
+
+std::string platform::Linux::readFile(std::string file)
+{
+    std::ifstream model(file);
+    std::string ret;
+    if (model.good())
+        ret = std::string(std::istreambuf_iterator<char>{model},
+                          std::istreambuf_iterator<char>());
+    return ret;
+}
+
+std::string platform::Linux::name()
+{
+    if (hasValidName()) {
+        auto model = readFile(LINUX_MODEL);
+        if (!model.empty())
+            return model;
+    }
+
+    return "generic-linux";
+}
+
+bool platform::Linux::hasValidName()
+{
+    return access(LINUX_MODEL, F_OK) != -1;
+}
+
+// Just returns default value
+std::string platform::Linux::prettyName()
+{
+    return "Generic linux device";
+}
+
+DeviceInfo::DeviceType platform::Linux::deviceType()
+{
+    return DeviceInfo::DeviceType::Unknown;
+}
+
+DeviceInfo::DriverType platform::Linux::driverType()
+{
+    return DeviceInfo::DriverType::Linux;
+}

--- a/src/platform/linux.h
+++ b/src/platform/linux.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 UBports foundation.
+ * Copyright (C) 2020 UBports foundation.
  * Author(s): Marius Gripsgard <marius@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify it under
@@ -18,24 +18,24 @@
 
 #pragma once
 
-#include "deviceinfo.h"
+#include "platform.h"
 
-class Config;
-class Platform;
-class Device {
+#include <memory>
+
+namespace platform {
+class Linux : public Platform {
 public:
-    Device();
+    Linux() = default;
 
-    std::string name();
-    std::string prettyName();
-    DeviceInfo::DeviceType deviceType();
-    DeviceInfo::DriverType driverType();
-    int gridUnit();
+    std::string name() override;
+    std::string prettyName() override;
+    DeviceInfo::DeviceType deviceType() override;
+    DeviceInfo::DriverType driverType() override;
 
-    // get props that does not have auto detection
-    std::string get(std::string prop, std::string defaultValue);
-    bool contains(std::string prop);
+    bool hasValidName() override;
+
+    static bool usable() { return true; };
 private:
-    std::shared_ptr<Platform> m_platform;
-    std::shared_ptr<Config> m_config;
+    std::string readFile(std::string file);
 };
+}

--- a/src/platform/platform.cpp
+++ b/src/platform/platform.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 UBports foundation.
+ * Copyright (C) 2020 UBports foundation.
  * Author(s): Marius Gripsgard <marius@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify it under
@@ -16,26 +16,15 @@
  *
  */
 
-#pragma once
+#include "platform.h"
+#include "linux.h"
+#include "halium.h"
 
-#include "deviceinfo.h"
+std::shared_ptr<Platform> Platform::create()
+{
+    if (platform::Halium::usable())
+        return std::make_shared<platform::Halium>();
 
-class Config;
-class Platform;
-class Device {
-public:
-    Device();
-
-    std::string name();
-    std::string prettyName();
-    DeviceInfo::DeviceType deviceType();
-    DeviceInfo::DriverType driverType();
-    int gridUnit();
-
-    // get props that does not have auto detection
-    std::string get(std::string prop, std::string defaultValue);
-    bool contains(std::string prop);
-private:
-    std::shared_ptr<Platform> m_platform;
-    std::shared_ptr<Config> m_config;
-};
+    // Linux is our fallback
+    return std::make_shared<platform::Linux>();
+}

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 UBports foundation.
+ * Copyright (C) 2020 UBports foundation.
  * Author(s): Marius Gripsgard <marius@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify it under
@@ -18,24 +18,23 @@
 
 #pragma once
 
+#include <memory>
+
 #include "deviceinfo.h"
 
-class Config;
-class Platform;
-class Device {
+class Platform {
 public:
-    Device();
+    Platform() = default;
 
-    std::string name();
-    std::string prettyName();
-    DeviceInfo::DeviceType deviceType();
-    DeviceInfo::DriverType driverType();
-    int gridUnit();
+    virtual std::string name() = 0;
+    virtual std::string prettyName() = 0;
+    virtual DeviceInfo::DeviceType deviceType() = 0;
+    virtual DeviceInfo::DriverType driverType() = 0;
 
-    // get props that does not have auto detection
-    std::string get(std::string prop, std::string defaultValue);
-    bool contains(std::string prop);
-private:
-    std::shared_ptr<Platform> m_platform;
-    std::shared_ptr<Config> m_config;
+    // Checks if the value returned is valid or default value
+    virtual bool hasValidName() { return false; };
+    virtual bool hasValidPrettyName() { return false; };
+    virtual bool hasValidDeviceType() { return false; };
+
+    static std::shared_ptr<Platform> create();
 };


### PR DESCRIPTION
This refactors the platform dependent information getter logic to
childclasss. This makes the code much cleaner but also avoid unneeded
cpu cycles for the *if halium* checks everywhere.

This is prepares for a *cached* platfrom childclass that will be able
to provide information to confined applications without needing to resort
to getprop or dts tree access. This makes it also possible to restrict
apps access to certain information.