### PR TITLE
Allow changing of CONFIG_PATH during compile-time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(TARGET deviceinfo)
 
 include_directories(headers)
 
-set(CONFIG_PATH ${CMAKE_INSTALL_FULL_SYSCONFDIR}/deviceinfo)
+set(CONFIG_PATH ${CMAKE_INSTALL_FULL_SYSCONFDIR}/deviceinfo CACHE STRING "")
 install(DIRECTORY configs/ DESTINATION ${CONFIG_PATH})
 
 add_subdirectory(headers)


### PR DESCRIPTION
```
This allows for e.g. a distribution to change the config path to a
different directory.

    cmake -B build -DCONFIG_PATH=/etc/lomiri-deviceinfo
```